### PR TITLE
TDL-23202 Remove setuptools for high-sev vulnerability fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,14 @@ from setuptools import setup
 
 setup(
     name='tap-calendly',
-    version='0.0.2',
+    version='0.0.3',
     packages=['tap_calendly', 'tap_calendly.tests'],
     url='https://github.com/singer-io/tap-calendly',
     license='',
     author='Nolan McCafferty',
     author_email='nolanmccafferty@gmail.com',
     description='Singer.io tap for Calendly',
-    install_requires=['setuptools~=41.0.1', 'requests~=2.25.1', 'singer-sdk'],
+    install_requires=[
+        'requests~=2.25.1',
+        'singer-sdk'],
 )


### PR DESCRIPTION
# Description of change
Addresses https://github.com/advisories/GHSA-r9hx-vwmv-q579 by removing setuptools which should be unnecessary.

# Manual QA steps
 - N/A
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
